### PR TITLE
Fix: Remove broken image link for hero_shape_1.svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
         </div>
       </div>
     </div>
-    <div class="cs_hero_shape"><img src="assets/img/hero_shape_1.svg" alt="Abstract decorative shape"></div>
+    <div class="cs_hero_shape"><!-- <img src="assets/img/hero_shape_1.svg" alt="Abstract decorative shape"> (Removed due to missing file) --></div>
   </section>
   <!-- End Hero Section -->
   <!-- Start Feature Section -->


### PR DESCRIPTION
Addresses your feedback regarding a broken image ("Abstract decorative shape") in the hero section. The image file `assets/img/hero_shape_1.svg` was found to be missing.

- Removed the `<img>` tag referencing the missing SVG from `index.html`.
- Replaced it with an HTML comment to prevent a broken image icon from displaying and to document the removal.